### PR TITLE
ci: use OIDC trusted publisher for npm releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,8 +46,14 @@ jobs:
     needs: [check]
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # `id-token: write` is required for OIDC trusted-publisher auth against
+    # npm. No static NPM_TOKEN is used — npm derives short-lived credentials
+    # from the workflow's OIDC identity, provided the package is configured
+    # with a GitHub trusted publisher pointing at this repo + workflow on
+    # npmjs.com.
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -59,6 +65,12 @@ jobs:
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
+
+      # npm trusted-publisher OIDC auth for `npm publish` requires npm 11.5.1+.
+      # Node 20 ships npm 10.x; provenance signing works on 10.x but the auth
+      # exchange against the registry returns 404 without 11.5.1+.
+      - name: Install npm 11.5.1+
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -73,10 +85,8 @@ jobs:
           if npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version 2>/dev/null; then
             echo "Version ${PACKAGE_VERSION} already published — skipping"
           else
-            npm publish --access public
+            npm publish --provenance --access public
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   create-release:
     needs: [publish-npm]


### PR DESCRIPTION
## Summary

Replace static \`NPM_TOKEN\` with GitHub Actions OIDC + npm trusted publisher. Same pattern shipped in \`fitzRoy-ts\` v2.2.0 release.

Changes to \`.github/workflows/release.yml\`:
- Add \`id-token: write\` permission on \`publish-npm\` job
- Install \`npm@latest\` before publish (OIDC auth for \`npm publish\` requires npm 11.5.1+; Node 20 ships 10.x)
- Add \`--provenance\` to \`npm publish\` so consumers get signed attestations
- Remove \`NODE_AUTH_TOKEN\` env var

## Required action before merging

Configure GitHub trusted publisher for \`@jackemcpherson/rds-js\` on npmjs.com:
1. https://www.npmjs.com/package/@jackemcpherson/rds-js/access
2. Settings → Trusted Publisher → GitHub Actions
3. Repository: \`jackemcpherson/rds-js\`, Workflow: \`release.yml\`, Allow \`npm publish\`

After merge, the \`NPM_TOKEN\` repo secret can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)