### PR TITLE
v0.3: input hardening — length validation, depth cap, decompression ceiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,23 @@ try {
 }
 ```
 
+## Untrusted input
+
+The parser is hardened for hostile bytes: negative or oversized length
+claims, truncated vectors, and malformed headers all surface as typed
+`RdsError`s (never hangs, backwards cursor movement, or uncontrolled
+`RangeError`s), and SEXP nesting is capped at 1,000 levels.
+
+Gzip payloads expand fully in memory. When parsing files you don't
+control, set a ceiling:
+
+```ts
+// Throws RdsError if the decompressed payload exceeds 64 MB.
+const data = await parseRds(buffer, { maxDecompressedBytes: 64 * 1024 * 1024 });
+```
+
+Unset, the size is unlimited — matching the common trusted-file case.
+
 ## Runtime compatibility
 
 Works in any environment with `DecompressionStream`, `DataView`, and `TextDecoder`:

--- a/src/decompress.ts
+++ b/src/decompress.ts
@@ -7,7 +7,7 @@ const BZIP2_MAGIC_1 = 0x5a; // 'Z'
 const XZ_MAGIC_0 = 0xfd;
 const XZ_MAGIC_1 = 0x37; // '7'
 
-export async function decompress(data: Uint8Array): Promise<Uint8Array> {
+export async function decompress(data: Uint8Array, maxBytes?: number): Promise<Uint8Array> {
   if (data.length < 2) {
     throw new RdsError("Input too short to be a valid RDS file");
   }
@@ -26,19 +26,22 @@ export async function decompress(data: Uint8Array): Promise<Uint8Array> {
   }
 
   if (b0 === GZIP_MAGIC_0 && b1 === GZIP_MAGIC_1) {
-    return decompressGzip(data);
+    return decompressGzip(data, maxBytes);
   }
 
   // Not compressed — return as-is
   return data;
 }
 
-async function decompressGzip(data: Uint8Array): Promise<Uint8Array> {
+async function decompressGzip(data: Uint8Array, maxBytes?: number): Promise<Uint8Array> {
   const ds = new DecompressionStream("gzip");
   const writer = ds.writable.getWriter();
   const reader = ds.readable.getReader();
 
   const writePromise = writer.write(data as unknown as BufferSource).then(() => writer.close());
+  // Observed here so an abort on the limit path (reader.cancel below) never
+  // becomes an unhandled rejection; the success path still awaits it.
+  writePromise.catch(() => undefined);
 
   const chunks: Uint8Array[] = [];
   let totalLength = 0;
@@ -48,6 +51,11 @@ async function decompressGzip(data: Uint8Array): Promise<Uint8Array> {
     if (done) break;
     chunks.push(value);
     totalLength += value.byteLength;
+    // Abort mid-stream so a decompression bomb never expands fully in memory.
+    if (maxBytes !== undefined && totalLength > maxBytes) {
+      await reader.cancel();
+      throw new RdsError(`Decompressed size exceeds the ${maxBytes}-byte limit`);
+    }
   }
 
   await writePromise;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,20 @@ export { RdsError, UnsupportedTypeError } from "./errors.js";
 export type { DataFrame } from "./types.js";
 
 import { decompress } from "./decompress.js";
+import { RdsError } from "./errors.js";
 import { parseStream } from "./parser.js";
 import type { DataFrame } from "./types.js";
+
+/** Options for {@link parseRds}. */
+export interface ParseRdsOptions {
+  /**
+   * Ceiling on the decompressed payload size in bytes. Gzip expands fully
+   * in memory, so without a cap a small crafted file (a decompression
+   * bomb) can exhaust memory. Unset = unlimited, matching the primary
+   * trusted-file use case.
+   */
+  readonly maxDecompressedBytes?: number | undefined;
+}
 
 /**
  * Parse an RDS file from a byte buffer.
@@ -17,12 +29,23 @@ import type { DataFrame } from "./types.js";
  * - Dates → ISO 8601 strings
  * - Named lists → plain objects
  *
- * @throws {RdsError} if the file is malformed or uses unsupported compression
+ * @param data - The raw (possibly gzipped) RDS bytes.
+ * @param options - Optional safety limits for untrusted input.
+ * @throws {RdsError} if the file is malformed, exceeds limits, or uses unsupported compression
  * @throws {UnsupportedTypeError} if the file contains unsupported R types (closures, environments, etc.)
  */
-export async function parseRds(data: Uint8Array): Promise<unknown> {
-  const decompressed = await decompress(data);
-  return parseStream(decompressed);
+export async function parseRds(data: Uint8Array, options?: ParseRdsOptions): Promise<unknown> {
+  const decompressed = await decompress(data, options?.maxDecompressedBytes);
+  try {
+    return parseStream(decompressed);
+  } catch (err) {
+    // Belt-and-braces: any allocation failure that slips past the length
+    // validation surfaces as a typed parse error, never a bare RangeError.
+    if (err instanceof RangeError) {
+      throw new RdsError(`Malformed RDS data: ${err.message}`);
+    }
+    throw err;
+  }
 }
 
 /**

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -71,7 +71,28 @@ export function parseStream(data: Uint8Array): unknown {
   return readItem(reader, refTable);
 }
 
+/**
+ * Maximum SEXP nesting depth. Real-world R objects nest a handful of
+ * levels; deeply nested VEC/pairlist chains in crafted input would
+ * otherwise overflow the stack as an uncontrolled RangeError.
+ */
+const MAX_DEPTH = 1_000;
+
+let currentDepth = 0;
+
 function readItem(reader: RdsReader, refs: RefTable): unknown {
+  if (currentDepth >= MAX_DEPTH) {
+    throw new RdsError(`Maximum nesting depth (${MAX_DEPTH}) exceeded`);
+  }
+  currentDepth++;
+  try {
+    return readItemUnguarded(reader, refs);
+  } finally {
+    currentDepth--;
+  }
+}
+
+function readItemUnguarded(reader: RdsReader, refs: RefTable): unknown {
   const flags = reader.readInt();
   const sexpType = flags & FLAGS.TYPE_MASK;
   const hasAttributes = (flags & FLAGS.ATTR_BIT) !== 0;
@@ -174,6 +195,11 @@ function readCharsxp(reader: RdsReader, gpFlags: number): string | null {
   if (length === -1) {
     return null;
   }
+  // -1 is the only meaningful negative; anything else is corrupt input
+  // that previously flowed into readBytes and moved the cursor backwards.
+  if (length < 0) {
+    throw new RdsError(`Invalid negative string length: ${length}`);
+  }
 
   const bytes = reader.readBytes(length);
 
@@ -230,13 +256,24 @@ function readAttributes(reader: RdsReader, refs: RefTable): RAttributes {
 
 function readLength(reader: RdsReader): number {
   const len = reader.readInt();
-  if (len === -1) {
-    // Long vector: two ints forming a 64-bit length
-    const hi = reader.readInt();
-    const lo = reader.readInt();
-    return hi * 0x100000000 + (lo >>> 0);
+  const resolved =
+    len === -1
+      ? // Long vector: two ints forming a 64-bit length
+        reader.readInt() * 0x100000000 + (reader.readInt() >>> 0)
+      : len;
+  if (resolved < 0) {
+    throw new RdsError(`Invalid negative vector length: ${resolved}`);
   }
-  return len;
+  // Every element of every vector type consumes at least one input byte,
+  // so a claimed length beyond the remaining data is provably corrupt —
+  // and rejecting it here turns a would-be giant allocation (uncontrolled
+  // RangeError) into a typed parse error.
+  if (resolved > reader.remaining) {
+    throw new RdsError(
+      `Vector length ${resolved} exceeds remaining data (${reader.remaining} bytes)`,
+    );
+  }
+  return resolved;
 }
 
 function readLogicalVector(

--- a/src/reader.ts
+++ b/src/reader.ts
@@ -60,6 +60,11 @@ export class RdsReader {
   }
 
   private ensureAvailable(n: number): void {
+    // A negative count would pass the end-of-data check below and move the
+    // cursor backwards — crafted input could loop the parser forever.
+    if (n < 0) {
+      throw new RdsError(`Invalid negative read length ${n} at offset ${this.pos}`);
+    }
     if (this.pos + n > this.bytes.byteLength) {
       throw new RdsError(
         `Unexpected end of data: needed ${n} bytes at offset ${this.pos}, but only ${this.remaining} remain`,

--- a/test/adversarial.test.ts
+++ b/test/adversarial.test.ts
@@ -17,7 +17,9 @@ function xdrStream(bodyInts: number[]): Uint8Array {
   out[0] = 0x58; // 'X'
   out[1] = 0x0a; // '\n'
   const view = new DataView(out.buffer);
-  ints.forEach((value, i) => view.setInt32(2 + i * 4, value, false));
+  ints.forEach((value, i) => {
+    view.setInt32(2 + i * 4, value, false);
+  });
   return out;
 }
 

--- a/test/adversarial.test.ts
+++ b/test/adversarial.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { parseRds, RdsError } from "../src/index.js";
+import { parseStream } from "../src/parser.js";
+
+/**
+ * Hand-built malformed inputs (TST-05). A binary parser's classic
+ * robustness hotspot is hostile input: every case here must surface as
+ * a typed RdsError — never a hang, infinite loop, stack overflow, or
+ * uncontrolled RangeError.
+ */
+
+/** Build an uncompressed XDR v2 stream: "X\n" + 3 header ints + body ints. */
+function xdrStream(bodyInts: number[]): Uint8Array {
+  const header = [2, 0x030203, 0x020300]; // version 2, writer, min reader
+  const ints = [...header, ...bodyInts];
+  const out = new Uint8Array(2 + ints.length * 4);
+  out[0] = 0x58; // 'X'
+  out[1] = 0x0a; // '\n'
+  const view = new DataView(out.buffer);
+  ints.forEach((value, i) => view.setInt32(2 + i * 4, value, false));
+  return out;
+}
+
+const INTSXP = 13;
+const STRSXP = 16;
+const CHARSXP = 9;
+const VECSXP = 19;
+const NILVALUE = 254;
+
+describe("adversarial inputs", () => {
+  it("rejects a negative vector length instead of looping or throwing RangeError", () => {
+    expect(() => parseStream(xdrStream([INTSXP, -5]))).toThrow(RdsError);
+    expect(() => parseStream(xdrStream([INTSXP, -5]))).toThrow(/negative vector length/i);
+  });
+
+  it("rejects a negative string length (other than the -1 NA sentinel)", () => {
+    // STRSXP of 1 element whose CHARSXP claims length -2.
+    expect(() => parseStream(xdrStream([STRSXP, 1, CHARSXP, -2]))).toThrow(
+      /negative string length/i,
+    );
+  });
+
+  it("rejects an oversized length claim before allocating", () => {
+    expect(() => parseStream(xdrStream([INTSXP, 50_000_000, 1, 2, 3]))).toThrow(
+      /exceeds remaining data/i,
+    );
+  });
+
+  it("rejects an absurd long-vector (64-bit) length claim", () => {
+    // -1 marks a long vector; hi/lo words claim ~2^33 elements.
+    expect(() => parseStream(xdrStream([INTSXP, -1, 2, 0]))).toThrow(/exceeds remaining data/i);
+  });
+
+  it("reports truncated vectors as end-of-data, not a hang", () => {
+    expect(() => parseStream(xdrStream([INTSXP, 3, 42]))).toThrow(/Unexpected end of data/i);
+  });
+
+  it("caps recursion depth on deeply nested generic vectors", () => {
+    // 2,000 nested one-element lists, terminated by NILVALUE.
+    const body: number[] = [];
+    for (let i = 0; i < 2_000; i++) body.push(VECSXP, 1);
+    body.push(NILVALUE);
+    expect(() => parseStream(xdrStream(body))).toThrow(/Maximum nesting depth/i);
+  });
+
+  it("rejects empty input", async () => {
+    await expect(parseRds(new Uint8Array(0))).rejects.toThrow(RdsError);
+  });
+
+  it("enforces the decompression ceiling on gzip bombs", async () => {
+    // 8 MB of zeros compresses to a few KB.
+    const bomb = new Uint8Array(8 * 1024 * 1024);
+    const cs = new CompressionStream("gzip");
+    const compressed = new Uint8Array(
+      await new Response(new Blob([bomb]).stream().pipeThrough(cs)).arrayBuffer(),
+    );
+    expect(compressed.byteLength).toBeLessThan(64 * 1024);
+
+    await expect(parseRds(compressed, { maxDecompressedBytes: 1024 * 1024 })).rejects.toThrow(
+      /exceeds the .*limit/i,
+    );
+  });
+
+  it("still parses a valid stream after a depth-cap failure (state unwinds)", () => {
+    const deep: number[] = [];
+    for (let i = 0; i < 2_000; i++) deep.push(VECSXP, 1);
+    deep.push(NILVALUE);
+    expect(() => parseStream(xdrStream(deep))).toThrow(/Maximum nesting depth/i);
+
+    // A simple 2-element integer vector parses fine immediately afterwards.
+    expect(parseStream(xdrStream([INTSXP, 2, 7, 9]))).toEqual([7, 9]);
+  });
+});


### PR DESCRIPTION
## Summary
- **SEC-13**: negative lengths (reader, vectors, strings) and oversized claims are rejected as typed `RdsError`s — previously a negative length moved the cursor *backwards* (non-termination) and oversized claims threw uncontrolled `RangeError`s
- **SEC-14**: SEXP nesting capped at 1,000; `parseRds(data, { maxDecompressedBytes })` aborts gzip bombs mid-stream; limits documented in README
- **TST-05**: adversarial corpus of hand-built malformed streams (negative/oversized/truncated lengths, 64-bit length claims, 2,000-deep nesting, an 8MB→KB gzip bomb), all asserting typed errors and clean state unwinding

Makes the parser credible for arbitrary input, not just trusted Fryzigg files. New optional parameter only — non-breaking; ship as v0.3.

## Test plan
- [x] 42 tests green (33 fixture round-trips unchanged + 9 adversarial), typecheck + biome clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)